### PR TITLE
Use null byte as string literal delimiter

### DIFF
--- a/lib/string_template/handler.rb
+++ b/lib/string_template/handler.rb
@@ -3,7 +3,7 @@
 module StringTemplate
   class Handler
     def self.call(template)
-      "%Q[#{template.source}]"
+      "%Q\0#{template.source}\0"
     end
 
     def self.handles_encoding?


### PR DESCRIPTION
This will reduce the possibility of accidental template termination.  (I'm half-joking, but just two cents.)