### PR TITLE
Update benchmark sciprt for benchmark_driver 0.9.0

### DIFF
--- a/benchmark.rb
+++ b/benchmark.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails'
-require 'action_view'
-require_relative 'lib/string_template'
-StringTemplate::Railtie.run_initializers
-require 'action_view/base'
 require 'benchmark_driver'
 
 Benchmark.driver do |x|
-  x.prelude %{ (view = Class.new(ActionView::Base).new('.')).instance_variable_set(:@world, 'world!') }
+  x.prelude %{
+    require 'rails'
+    require 'action_view'
+    require 'string_template'
+    StringTemplate::Railtie.run_initializers
+    require 'action_view/base'
+
+    (view = Class.new(ActionView::Base).new('.')).instance_variable_set(:@world, 'world!')
+  }
   x.report 'erb', %{ view.render(template: 'hello', handlers: 'erb') }
   x.report 'string', %{ view.render(template: 'hello', handlers: 'string') }
-  x.compare!
 end

--- a/string_template.gemspec
+++ b/string_template.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'benchmark_driver'
+  spec.add_development_dependency 'benchmark_driver', '>= 0.9.0'
 end


### PR DESCRIPTION
benchmark_driver v0.9.0 had some breaking changes:

* Benchmark script is no longer executed in the same context. All `require` should be in the prelude.
* Meaning of `x.compare!` is changed and the behavior is made default. It's no longer needed.

But the execution time of benchmark is much shortened.

## before

```
$ time bundle exec ruby benchmark.rb
Warming up --------------------------------------
                 erb     1.061k i/100ms
              string     1.907k i/100ms
Calculating -------------------------------------
                 erb    12.177k i/s -     53.032k in 4.355258s (82.13us/i)
              string    21.475k i/s -     95.330k in 4.439211s (46.57us/i)

Comparison:
              string:     21474.5 i/s
                 erb:     12176.5 i/s - 1.76x  slower

bundle exec ruby benchmark.rb  135.96s user 1.14s system 98% cpu 2:19.31 total
```

## after

```
$ time bundle exec ruby benchmark.rb
Warming up --------------------------------------
                 erb    13.303k i/s
              string    23.238k i/s
Calculating -------------------------------------
                 erb    13.363k i/s -     39.909k times in 2.986561s (74.83μs/i)
              string    24.683k i/s -     69.713k times in 2.824316s (40.51μs/i)

Comparison:
              string:     24683.1 i/s
                 erb:     13362.9 i/s - 1.85x  slower

bundle exec ruby benchmark.rb  11.07s user 0.58s system 98% cpu 11.834 total
```