### PR TITLE
Fix Rails 6 errors in StringTemplateTest

### DIFF
--- a/test/string_template_test.rb
+++ b/test/string_template_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class StringTemplateTest < Minitest::Test
   def setup
-    @view = Class.new(ActionView::Base).new(__dir__)
+    @view = Class.new(ActionView::Base).new(ActionView::LookupContext.new(__dir__))
     super
   end
 


### PR DESCRIPTION
Fixing failures like https://travis-ci.org/amatsuda/string_template/builds/584220386